### PR TITLE
fix log level

### DIFF
--- a/server/echologger.go
+++ b/server/echologger.go
@@ -138,15 +138,15 @@ func (l Logger) Debugj(j log.JSON) {
 
 // Print implements echo.Logger#Print.
 func (l Logger) Print(i ...interface{}) {
-	l.Debug(fmt.Sprintf("%v", i))
+	l.Info(fmt.Sprintf("%v", i))
 }
 
 // Printf implements echo.Logger#Printf.
 func (l Logger) Printf(format string, args ...interface{}) {
-	l.Debug(fmt.Sprintf(format, args...))
+	l.Info(fmt.Sprintf(format, args...))
 }
 
 // Printj implements echo.Logger#Printj.
 func (l Logger) Printj(j log.JSON) {
-	l.Debug(fmt.Sprintf("%+v", j))
+	l.Info(fmt.Sprintf("%+v", j))
 }


### PR DESCRIPTION
Echo uses Logger.Print when logging stack traces in the panic recover middleware. By switiching to info level we can make sure the log is visible in production when running with log level "info".