### PR TITLE
make logged headers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You need to tell the envloader in which folder to look for the `.env` files. By 
 ## Usage
 ```go
 import (
-	toolkit "github.com/fastbill/go-service-toolkit/v2"
+	toolkit "github.com/fastbill/go-service-toolkit/v3"
 )
 
 
@@ -24,7 +24,7 @@ func main() {
 ```
 
 # Observability - Logging and Metrics
-We bundle logging and capturing custom metrics in one `Obs` struct (short for observance). In the future tools for tracing might also be added. Due to the bundling only one struct needs to be passed around in the application and not 2 or 3. Additionally the observance struct provides a method to create request specific observance instances that automatically add url, path and request id to every log message created with that instance. It also adds the account id if it was found in the request header. The headers that are checked for this can be configured via `observance.RequestIDHeader` and `observance.AccountIDHeader`.
+We bundle logging and capturing custom metrics in one `Obs` struct (short for observance). In the future tools for tracing might also be added. Due to the bundling only one struct needs to be passed around in the application and not 2 or 3. Additionally the observance struct provides a method to create request specific observance instances that automatically add url, path and request id to every log message created with that instance. It also adds the request headers specified via `LoggedHeaders` to the logger with the given field name when the method `CopyWithRequest` is used.
 
 We use [Logrus](https://github.com/sirupsen/logrus) as logger under the hood but it is wrapped with a custom interface so we do not depend directly on the interface provided by Logrus. Logs will be written to StdOut in JSON format. If you pass a Sentry URL and version all log entries with level error or higher will be pushed to Sentry. This is done via hooks in Logrus.
 
@@ -35,7 +35,7 @@ The `Obs` struct has a `PanicRecover` method that can be used as deferred functi
 import (
 	"time"
 
-	"github.com/fastbill/go-service-toolkit/v2"
+	"github.com/fastbill/go-service-toolkit/v3"
 )
 
 func main() {
@@ -46,6 +46,9 @@ func main() {
 		Version:              "1.0.0",
 		MetricsURL:           "http://example.com",
 		MetricsFlushInterval: 1 * time.Second,
+		LoggedHeaders: map[string]string{
+			"FastBill-RequestId": "requestId",
+		},
 	}
 
 	obs := toolkit.MustNewObs(obsConfig)
@@ -83,7 +86,7 @@ Additionally `MustEnsureDBMigrations` runs all migrations from the given folder 
 ## Usage
 ```go
 import (
-    "github.com/fastbill/go-service-toolkit/v2"
+    "github.com/fastbill/go-service-toolkit/v3"
 )
 
 func main() {
@@ -112,7 +115,7 @@ The function `MustNewCache` sets up a new REDIS client. A prefix can be provided
 ## Usage
 ```go
 import (
-    "github.com/fastbill/go-service-toolkit/v2"
+    "github.com/fastbill/go-service-toolkit/v3"
 )
 
 func main() {
@@ -131,11 +134,11 @@ The server package sets up an [Echo](https://echo.labstack.com/) server that inc
 ## Usage
 ```go
 import (
-    "github.com/fastbill/go-service-toolkit/v2/server"
+    "github.com/fastbill/go-service-toolkit/v3/server"
 )
 
 func main() {
-    echoServer, connectionsClosed := server.New(logger, "https://example.com", "1m")
+    echoServer, connectionsClosed := server.New(obs, "https://example.com", "1m")
 	
 	// Set up routes etc.
 
@@ -219,7 +222,7 @@ As response, the `CallHandler` method returns the error that the echo handler re
 ```go
 import (
 	"testing"
-    "github.com/fastbill/go-service-toolkit/v2/handlertest"
+    "github.com/fastbill/go-service-toolkit/v3/handlertest"
 )
 
 func TestMyHandler(t *testing.T) {
@@ -236,7 +239,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastbill/go-service-toolkit/v2/handlertest"
+	"github.com/fastbill/go-service-toolkit/v3/handlertest"
 	"github.com/labstack/echo/v4"
 )
 

--- a/database/gorm.go
+++ b/database/gorm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fastbill/go-service-toolkit/v2/observance"
+	"github.com/fastbill/go-service-toolkit/v3/observance"
 
 	// import migrate mysql, postgres driver
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"

--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	toolkit "github.com/fastbill/go-service-toolkit/v2"
+	toolkit "github.com/fastbill/go-service-toolkit/v3"
 	"github.com/labstack/echo/v4"
 )
 
@@ -28,6 +28,9 @@ func main() {
 		Version:              os.Getenv("APP_VERSION"),
 		MetricsURL:           os.Getenv("METRICS_URL"),
 		MetricsFlushInterval: 1 * time.Second,
+		LoggedHeaders: map[string]string{
+			"FastBill-RequestId": "requestId",
+		},
 	}
 	obs := toolkit.MustNewObs(obsConfig)
 	defer obs.PanicRecover()
@@ -59,7 +62,7 @@ func main() {
 	}()
 
 	// Set up the server.
-	e, connectionsClosed := toolkit.MustNewServer(obs.Logger, "")
+	e, connectionsClosed := toolkit.MustNewServer(obs, "")
 
 	// Set up a routes and handlers.
 	e.POST("/users", func(c echo.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fastbill/go-service-toolkit/v2
+module github.com/fastbill/go-service-toolkit/v3
 
 go 1.13
 
@@ -8,8 +8,7 @@ require (
 	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/fastbill/go-httperrors/v2 v2.0.0
 	github.com/getsentry/raven-go v0.2.0 // indirect
-	github.com/go-playground/locales v0.12.1 // indirect
-	github.com/go-playground/universal-translator v0.16.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator v9.21.0+incompatible
 	github.com/go-redis/redis/v7 v7.0.0-beta.4
 	github.com/golang-migrate/migrate/v4 v4.6.2

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,10 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-playground/locales v0.12.1 h1:2FITxuFt/xuCNP1Acdhv62OzaCiviiE4kotfhkmOqEc=
-github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
-github.com/go-playground/universal-translator v0.16.0 h1:X++omBR/4cE2MNg91AoC3rmGrCjJ8eAeUP/K/EKx4DM=
-github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator v9.21.0+incompatible h1:UEjUH0DTklaRzkIbMMRb+qcoquPDi4ZlTNInpjuEcUU=
 github.com/go-playground/validator v9.21.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-redis/redis/v7 v7.0.0-beta.4 h1:p6z7Pde69EGRWvlC++y8aFcaWegyrKHzOBGo0zUACTQ=

--- a/handlertest/handlertest.go
+++ b/handlertest/handlertest.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	toolkit "github.com/fastbill/go-service-toolkit/v2"
-	"github.com/fastbill/go-service-toolkit/v2/observance"
+	toolkit "github.com/fastbill/go-service-toolkit/v3"
+	"github.com/fastbill/go-service-toolkit/v3/observance"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -70,7 +70,7 @@ func (s *Suite) CallHandler(t *testing.T, handlerFunc echo.HandlerFunc, params *
 	rec := httptest.NewRecorder()
 
 	obs := &observance.Obs{Logger: observance.NewTestLogger()}
-	e, _ := toolkit.MustNewServer(obs.Logger, "")
+	e, _ := toolkit.MustNewServer(obs, "")
 	ctx := e.NewContext(req, rec)
 
 	addPathParams(ctx, params.PathParams)

--- a/observance/obs.go
+++ b/observance/obs.go
@@ -55,7 +55,7 @@ func NewObs(config Config) (*Obs, error) {
 
 // CopyWithRequest creates a new observance and adds request-specific fields to
 // the logger (and maybe at some point to the other parts of observance, too).
-// The headers specified in the config (LoggedHeaders) will be added as log fields with their speficied field names.
+// The headers specified in the config (LoggedHeaders) will be added as log fields with their specified field names.
 func (o *Obs) CopyWithRequest(r *http.Request) *Obs {
 	obCopy := *o
 	obs := &obCopy

--- a/observance/obs.go
+++ b/observance/obs.go
@@ -7,12 +7,6 @@ import (
 	"time"
 )
 
-// These variables define which headers are checked for finding the request and account id.
-var (
-	RequestIDHeader = "Fastbill-Outer-RequestId"
-	AccountIDHeader = "Fastbill-AccountId"
-)
-
 // Config contains all config variables for setting up observability (logging, metrics).
 type Config struct {
 	AppName              string
@@ -21,13 +15,19 @@ type Config struct {
 	Version              string
 	MetricsURL           string
 	MetricsFlushInterval time.Duration
+	// LoggedHeaders is map of header names and log field names. If those headers are present in the request,
+	// the method CopyWithRequest will add them to the logger with the given field name.
+	// E.g. map[string]string{"FastBill-RequestId": "requestId"} means that if the header "FastBill-RequestId" was found
+	// in the request headers the value will be added to the logger under the name "requestId".
+	LoggedHeaders map[string]string
 }
 
 // Obs is a wrapper for all things that helps to observe the operation of
 // the service: logging, monitoring, tracing
 type Obs struct {
-	Logger  Logger
-	Metrics Measurer
+	Logger        Logger
+	Metrics       Measurer
+	loggedHeaders map[string]string
 }
 
 // NewObs creates a new observance instance for logging.
@@ -39,33 +39,37 @@ func NewObs(config Config) (*Obs, error) {
 		return nil, err
 	}
 
+	obs := &Obs{
+		Logger:        log,
+		loggedHeaders: config.LoggedHeaders,
+	}
+
 	if config.MetricsURL == "" {
-		return &Obs{Logger: log}, nil
+		return obs, nil
 	}
 
 	metrics := NewPrometheusMetrics(config.MetricsURL, config.AppName, config.MetricsFlushInterval, log)
-	return &Obs{
-		Logger:  log,
-		Metrics: metrics,
-	}, nil
+	obs.Metrics = metrics
+	return obs, nil
 }
 
 // CopyWithRequest creates a new observance and adds request-specific fields to
-// the logger (and maybe at some point to the other parts of observance, too)
-// Logs url, method, requestId and accountId (if present)
+// the logger (and maybe at some point to the other parts of observance, too).
+// The headers specified in the config (LoggedHeaders) will be added as log fields with their speficied field names.
 func (o *Obs) CopyWithRequest(r *http.Request) *Obs {
 	obCopy := *o
 	obs := &obCopy
 
 	obs.Logger = obs.Logger.WithFields(Fields{
-		"url":       r.RequestURI,
-		"method":    r.Method,
-		"requestId": r.Header.Get(RequestIDHeader),
+		"url":    r.RequestURI,
+		"method": r.Method,
 	})
 
-	accountID := r.Header.Get(AccountIDHeader)
-	if accountID != "" {
-		obs.Logger = obs.Logger.WithField("accountId", accountID)
+	for headerName, fieldName := range o.loggedHeaders {
+		headerValue := r.Header.Get(headerName)
+		if headerValue != "" {
+			obs.Logger = obs.Logger.WithField(fieldName, headerValue)
+		}
 	}
 
 	return obs

--- a/observance/obs_test.go
+++ b/observance/obs_test.go
@@ -12,6 +12,10 @@ func TestCopyWithRequest(t *testing.T) {
 	config := Config{
 		AppName:  "testApp",
 		LogLevel: "debug",
+		LoggedHeaders: map[string]string{
+			"Fastbill-Outer-RequestId": "requestId",
+			"Fastbill-AccountId":       "accountId",
+		},
 	}
 	obs, err := NewObs(config)
 	assert.NoError(t, err)

--- a/server/echologger.go
+++ b/server/echologger.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/fastbill/go-service-toolkit/v2/observance"
+	"github.com/fastbill/go-service-toolkit/v3/observance"
 	"github.com/labstack/gommon/log"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/fastbill/go-httperrors/v2"
-	"github.com/fastbill/go-service-toolkit/v2/observance"
+	"github.com/fastbill/go-service-toolkit/v3/observance"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -23,7 +22,7 @@ var defaultBinder = echo.DefaultBinder{}
 
 // New creates an echo server instance with the given logger, CORS middleware if CORSOrigins was supplied
 // and optionally a timeout setting that is applied for read and write.
-func New(logger observance.Logger, CORSOrigins string, timeout ...string) (*echo.Echo, chan struct{}, error) {
+func New(obs *observance.Obs, CORSOrigins string, timeout ...string) (*echo.Echo, chan struct{}, error) {
 	timeoutDuration := defaultTimeout
 	if len(timeout) > 0 {
 		parsedTimeout, err := time.ParseDuration(timeout[0])
@@ -41,10 +40,10 @@ func New(logger observance.Logger, CORSOrigins string, timeout ...string) (*echo
 	echoServer.Server.ReadTimeout = timeoutDuration
 	echoServer.Server.WriteTimeout = timeoutDuration
 	echoServer.Server.ReadHeaderTimeout = timeoutDuration
-	echoServer.HTTPErrorHandler = HTTPErrorHandler(logger)
+	echoServer.HTTPErrorHandler = HTTPErrorHandler(obs)
 	echoServer.Binder = &bindValidator{}
 	echoServer.Validator = NewValidator()
-	echoServer.Logger = Logger{logger}
+	echoServer.Logger = Logger{obs.Logger}
 	echoServer.DisableHTTP2 = true
 	echoServer.Pre(middleware.RemoveTrailingSlash())
 	echoServer.Use(middleware.Recover())
@@ -61,14 +60,14 @@ func New(logger observance.Logger, CORSOrigins string, timeout ...string) (*echo
 	sc := make(chan os.Signal)
 	go func() {
 		s := <-sc
-		logger.WithField("signal", s).Warn("shutting down gracefully")
+		obs.Logger.WithField("signal", s).Warn("shutting down gracefully")
 
 		c, cancel := context.WithTimeout(context.Background(), 9*time.Second)
 		defer cancel()
 
 		err := echoServer.Shutdown(c)
 		if err != nil {
-			logger.Error(err)
+			obs.Logger.Error(err)
 		}
 		close(connsClosed)
 	}()
@@ -80,17 +79,13 @@ func New(logger observance.Logger, CORSOrigins string, timeout ...string) (*echo
 // HTTPErrorHandler retruns an error handler that can be used in echo to overwrite the default Echo error handler.
 // It can send responses for echo.HTTPError, htttperrors.HTTPError and standard errors.
 // Standard errors also get logged.
-func HTTPErrorHandler(logger observance.Logger) func(err error, c echo.Context) {
+func HTTPErrorHandler(obs *observance.Obs) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
 		// Log error if it is not an HTTPError or an Echo error.
 		needsLogging := !isHTTPOrEchoError(err)
 		if needsLogging {
-			logger.WithFields(logrus.Fields{
-				"url":       c.Request().RequestURI,
-				"method":    c.Request().Method,
-				"requestId": c.Request().Header.Get(observance.RequestIDHeader),
-				"accountId": c.Request().Header.Get(observance.AccountIDHeader),
-			}).Error(err)
+			requestObs := obs.CopyWithRequest(c.Request())
+			requestObs.Logger.Error(err)
 		}
 
 		httpError := buildHTTPError(err)

--- a/toolkit.go
+++ b/toolkit.go
@@ -1,11 +1,11 @@
 package toolkit
 
 import (
-	"github.com/fastbill/go-service-toolkit/v2/cache"
-	"github.com/fastbill/go-service-toolkit/v2/database"
-	"github.com/fastbill/go-service-toolkit/v2/envloader"
-	"github.com/fastbill/go-service-toolkit/v2/observance"
-	"github.com/fastbill/go-service-toolkit/v2/server"
+	"github.com/fastbill/go-service-toolkit/v3/cache"
+	"github.com/fastbill/go-service-toolkit/v3/database"
+	"github.com/fastbill/go-service-toolkit/v3/envloader"
+	"github.com/fastbill/go-service-toolkit/v3/observance"
+	"github.com/fastbill/go-service-toolkit/v3/server"
 
 	"github.com/jinzhu/gorm"
 	"github.com/labstack/echo/v4"
@@ -63,8 +63,8 @@ func MustEnsureDBMigrations(folderPath string, config DBConfig) {
 }
 
 // MustNewServer sets up a new Echo server.
-func MustNewServer(logger observance.Logger, CORSOrigins string, timeout ...string) (*echo.Echo, chan struct{}) {
-	echoServer, connectionsClosed, err := server.New(logger, CORSOrigins, timeout...)
+func MustNewServer(obs *observance.Obs, CORSOrigins string, timeout ...string) (*echo.Echo, chan struct{}) {
+	echoServer, connectionsClosed, err := server.New(obs, CORSOrigins, timeout...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
There was a design flaw in the toolkit. I knew it when I wrote it but didn't had the time to fix it then.
The issue is that the header values that are logged when using a request specific logger (via `observance.CopyWithRequest`) were hard coded in the toolkit. Now that we will have different headers for different products that doesn't work anymore. And it didn't make much sense anyway.

This MR fixes the issue.